### PR TITLE
Moved Launch TIDE JupyterHub button from JH-Overview to JH-Getting Access

### DIFF
--- a/docs/jupyterhub/gettingaccess.md
+++ b/docs/jupyterhub/gettingaccess.md
@@ -13,7 +13,12 @@ permalink: /jupyterhub/gettingaccess
 ## CSU TIDE JupyterHub
 TIDE is available for research use across the CSU system. To get access, please review [Using TIDE](https://tide.sdsu.edu/usingtide/){:target="_blank"} and submit a [TIDE Support Request](https://tide.sdsu.edu/tide-support-request/){:target="_blank"} to be granted access to JupyterHub.
 
-Once a support request is submitted and reviewed, a member of the TIDE team will reach out with next-steps to complete the set up. Refer to the [Quickstart](/jupyterhub/quickstart) once this process is completed.
+Once a support request is submitted and reviewed, a member of the TIDE team will reach out with next-steps to complete the set up. Once this process is completed, refer to the [Quickstart](/jupyterhub/quickstart) guide and use one of the launch options below.
+
+{: .note }
+Your school credentials may not work when using the following button, check for a [campus specific JupyterHub](#campus-specific-jupyterhubs) for your school before submitting a help ticket.
+
+[Launch TIDE JupyterHub](https://csu-tide-jupyterhub.nrp-nautilus.io/){: .btn .btn-green }{:target="_blank"}
 
 ## Campus-Specific JupyterHubs
 

--- a/docs/jupyterhub/index.md
+++ b/docs/jupyterhub/index.md
@@ -15,7 +15,7 @@ JupyterHub is the latest web-based interactive development environment for noteb
 
 TIDE JupyterHub users are allocated 50 GB (gigabytes) of JupyterHub storage (campus-specific amounts may differ). If you need additional space, please see [Requesting Storage](/storage-services/requesting-storage). To check your storage in use, refer to the [Check Disk Quota](/jupyterhub/faqs/diskquota) FAQ.
 
-[Launch TIDE JupyterHub](https://csu-tide-jupyterhub.nrp-nautilus.io/){: .btn .btn-green }{:target="_blank"}
+To launch JupyterHub, see [Getting Access](/jupyterhub/gettingaccess).
 
 ## Using JupyterLab
 JupyterLab is a versatile interactive development environment (IDE) widely used for computing and research across various disciplines. It allows users to create and manage Jupyter notebooks, code, and data visualizations in a single interface. TIDE users perform research and develop code in this simple, yet powerful browser-based IDE. 


### PR DESCRIPTION
- Removed Launch TIDE JupyterHub button from JupyterHub-Overview page
- Added Launch TIDE JupyterHub button to JupyterHub-Getting Access page
- Added note about campus specific JHs